### PR TITLE
Publishing Monorepo Packages

### DIFF
--- a/docs/DRAFT_PUBLISH.md
+++ b/docs/DRAFT_PUBLISH.md
@@ -17,3 +17,4 @@ TODO: Create script that
 - create a new git tag
 - cleanup branches?
 - run `yarn release`
+- Add to CI/CD pipeline

--- a/docs/DRAFT_PUBLISH.md
+++ b/docs/DRAFT_PUBLISH.md
@@ -1,0 +1,19 @@
+# Publishing Monorepo Packages
+
+## Migrate away from release-it.js
+
+Historically I was using release-it to auto publish package, while it works fine with npm on single package, I find it buggy with monorepo.
+This document is a wip of new steps to publish packages in monorepo.
+
+## Steps
+
+TODO: Create script that
+- first check if current package version is already published
+- IF NOT PUBLISHED --> bump version in package.json (Minor, Major, Patch)
+- commit any pending changes
+- run `yarn build`
+- run `yarn test`
+- update changelogs based on last commits (pending user approval and allow for editing)
+- create a new git tag
+- cleanup branches?
+- run `yarn release`

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siteed/design-system",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": "Arthur Breton <abreton@siteed.net> (https://github.com/deeeed)",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This PR migrates away from using release-it.js for auto-publishing packages in the monorepo. It introduces new steps for publishing packages, including version bumping, building, testing, updating changelogs, creating git tags, and adding to the CI/CD pipeline.