### PR TITLE
Refactor Skeleton component to use default skeleton items

### DIFF
--- a/packages/design-system/src/components/skeleton/skeleton.stories.tsx
+++ b/packages/design-system/src/components/skeleton/skeleton.stories.tsx
@@ -49,11 +49,6 @@ const SkeletonMeta: Meta<SkeletonProps> = {
     },
   },
   args: {
-    items: [
-      { circles: 1, bars: 3 },
-      { circles: 1, bars: 2 },
-      { circles: 1, bars: 1 },
-    ],
     circleSize: 50,
     barHeight: 20,
     color: '#ccc',

--- a/packages/design-system/src/components/skeleton/skeleton.tsx
+++ b/packages/design-system/src/components/skeleton/skeleton.tsx
@@ -29,8 +29,12 @@ const getStyles = () => {
   });
 };
 
+const defaultSkeletonItems: SkeletonItem[] = [
+  { circles: 1, bars: 3 },
+  { circles: 1, bars: 3 },
+];
 export interface SkeletonProps {
-  items: SkeletonItem[];
+  items?: SkeletonItem[];
   circleSize?: number;
   barHeight?: number;
   color?: string;
@@ -40,7 +44,7 @@ export interface SkeletonProps {
   style?: StyleProp<ViewStyle>;
 }
 export const Skeleton = ({
-  items,
+  items = defaultSkeletonItems,
   circleSize = 50,
   barHeight = 20,
   color = '#ccc',


### PR DESCRIPTION
This pull request refactors the Skeleton component to use default skeleton items. Previously, the component required the items prop to be passed in, but now it has a default value of [{ circles: 1, bars: 3 }, { circles: 1, bars: 3 }]. This simplifies the usage of the component and reduces the need for explicit prop passing.